### PR TITLE
Move DrainableFuelLoader.Load call into FMLCommonSetupEvent call

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon =false
 
 mc_version = 1.19.2
 
-mod_version = 2.1.0
+mod_version = 2.1.1
 
 create_minecraft_version = 1.19.2
 flywheel_minecraft_version = 1.19.2

--- a/src/main/java/com/forsteri/createliquidfuel/CreateLiquidFuel.java
+++ b/src/main/java/com/forsteri/createliquidfuel/CreateLiquidFuel.java
@@ -1,12 +1,12 @@
 package com.forsteri.createliquidfuel;
 
 
-import com.forsteri.createliquidfuel.core.DrainableFuelLoader;
-import com.forsteri.createliquidfuel.core.LiquidBurnerFuelJsonLoader;
+import com.forsteri.createliquidfuel.eventhandlers.ForgeEventHandler;
+import com.forsteri.createliquidfuel.eventhandlers.ModEventHandler;
+
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.AddReloadListenerEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(value = CreateLiquidFuel.MOD_ID)
@@ -16,16 +16,7 @@ public class CreateLiquidFuel {
     public static final String MOD_ID = "createliquidfuel";
 
     public CreateLiquidFuel() {
-        MinecraftForge.EVENT_BUS.register(this);
-
-        DrainableFuelLoader.load();
-    }
-
-    @Mod.EventBusSubscriber
-    public static class ForgeEvents {
-        @SubscribeEvent
-        public static void addReloadListeners(AddReloadListenerEvent event) {
-            event.addListener(LiquidBurnerFuelJsonLoader.INSTANCE);
-        }
+        MinecraftForge.EVENT_BUS.register(ForgeEventHandler.class);
+        FMLJavaModLoadingContext.get().getModEventBus().register(ModEventHandler.class);
     }
 }

--- a/src/main/java/com/forsteri/createliquidfuel/eventhandlers/ForgeEventHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/eventhandlers/ForgeEventHandler.java
@@ -1,0 +1,15 @@
+package com.forsteri.createliquidfuel.eventhandlers;
+
+import com.forsteri.createliquidfuel.core.LiquidBurnerFuelJsonLoader;
+
+import net.minecraftforge.event.AddReloadListenerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber
+public class ForgeEventHandler {
+    @SubscribeEvent
+    public static void addReloadListeners(AddReloadListenerEvent event) {
+        event.addListener(LiquidBurnerFuelJsonLoader.INSTANCE);
+    }
+}

--- a/src/main/java/com/forsteri/createliquidfuel/eventhandlers/ModEventHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/eventhandlers/ModEventHandler.java
@@ -1,0 +1,16 @@
+package com.forsteri.createliquidfuel.eventhandlers;
+
+import com.forsteri.createliquidfuel.CreateLiquidFuel;
+import com.forsteri.createliquidfuel.core.DrainableFuelLoader;
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+
+@Mod.EventBusSubscriber(modid = CreateLiquidFuel.MOD_ID)
+public class ModEventHandler {
+    @SubscribeEvent
+    public static void commonSetup(FMLCommonSetupEvent event) {
+        event.enqueueWork(DrainableFuelLoader::load);
+    }
+}


### PR DESCRIPTION
Moves DrainableFuelLoader.Load call into FMLCommonSetupEvent call - as per issue: https://github.com/RuochenFu21/CreateLiquidFuel/issues/12

I also moved the event handlers into separate files, as I couldn't get them registering properly otherwise.

This is the 1.19.2 version of PR https://github.com/RuochenFu21/CreateLiquidFuel/pull/14