### PR TITLE
Allow Heat level KINDLED with high fuel amount

### DIFF
--- a/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
@@ -54,9 +54,9 @@ public class BurnerStomachHandler {
             burnerAccessor.createliquidfuel$invokeSetBlockHeat(BlazeBurnerBlock.HeatLevel.SEETHING);
         else {
             int burnTime = burnerProperty.getFirst();
+            int allFluidRemainingBurnTime = fluidAmount * burnTime;
 
             //Copy from BlazeBurnerBlockEntity#getHeatLevel, case NORMAL.
-            int allFluidRemainingBurnTime = fluidAmount * burnTime;
             boolean lowPercent = (double)allFluidRemainingBurnTime / 10000.0 < 0.0125;
             BlazeBurnerBlock.HeatLevel level = lowPercent ? BlazeBurnerBlock.HeatLevel.FADING : BlazeBurnerBlock.HeatLevel.KINDLED;
 

--- a/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
@@ -43,16 +43,26 @@ public class BurnerStomachHandler {
         boolean fluidSuperHeats = burnerProperty.getSecond();
 
         int mbConsuming = burnerProperty.getThird();
+        int fluidAmount = stomach.getFluid().getAmount();
 
-        if (stomach.getFluid().getAmount() < mbConsuming) {
+        if (fluidAmount < mbConsuming) {
             stomach.getFluid().setAmount(0);
             return;
         }
 
         if (fluidSuperHeats)
             burnerAccessor.createliquidfuel$invokeSetBlockHeat(BlazeBurnerBlock.HeatLevel.SEETHING);
-        else
-            burnerAccessor.createliquidfuel$invokeSetBlockHeat(BlazeBurnerBlock.HeatLevel.FADING);
+        else {
+            int burnTime = burnerProperty.getFirst();
+
+            //Copy from BlazeBurnerBlockEntity#getHeatLevel, case NORMAL.
+            int allFluidRemainingBurnTime = fluidAmount * burnTime;
+            boolean lowPercent = (double)allFluidRemainingBurnTime / 10000.0 < 0.0125;
+            BlazeBurnerBlock.HeatLevel level = lowPercent ? BlazeBurnerBlock.HeatLevel.FADING : BlazeBurnerBlock.HeatLevel.KINDLED;
+
+            burnerAccessor.createliquidfuel$invokeSetBlockHeat(level);
+        }
+
 
         int newBurnTime = burnerAccessor.createliquidfuel$getRemainingBurnTime() + burnerProperty.getFirst();
 


### PR DESCRIPTION
Hi, I was having toruble using lava to generate Raw Chicken using Create: Egg Production as you can see here: https://github.com/Aupoex/CreateEggProduction/issues/4
and I've noticed that CreateLiquidFuel forces the HeatLevel to FADING.

I changed the code so it can be KINDLED when there is a lot of fuel inside the Blaze Burner, in a similar way that it does with regular fuel.

In theory, unless I'm missing something, using Lava for example would set it to KINDLED if it has more than 6(mB?) remaining, and FADING with 6 or less (6 * 20 / 10000 < 0.0125).