### PR TITLE
Fix burner consuming fluid handler items and fix interaction with Create Diesel Generator

### DIFF
--- a/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
@@ -22,23 +22,23 @@ import java.util.Map;
 public class BurnerStomachHandler {
     public static Map<Fluid, Pair<ResourceLocation, Triplet<Integer, Boolean, Integer>>> LIQUID_BURNER_FUEL_MAP = new HashMap<>();
 
-    public static void tick(SmartBlockEntity entity) {
-        if (!(entity instanceof BlazeBurnerAccessor burnerAccessor)) return;
+    public static boolean tick(SmartBlockEntity entity) {
+        if (!(entity instanceof BlazeBurnerAccessor burnerAccessor)) return false;
 
         @SuppressWarnings("DataFlowIssue")
         SmartFluidTank stomach = (SmartFluidTank) entity.getCapability(ForgeCapabilities.FLUID_HANDLER).orElse(null);
 
         //noinspection ConstantValue
         if (stomach == null)
-            return;
+            return false;
 
-        if (stomach.getFluid().getAmount() <= 0) return;
+        if (stomach.getFluid().getAmount() <= 0) return false;
 
         Triplet<Integer, Boolean, Integer> burnerProperty = LIQUID_BURNER_FUEL_MAP.get(
                 stomach.getFluid().getFluid()).getSecond();
 
         if (burnerProperty == null)
-            return;
+            return false;
 
         boolean fluidSuperHeats = burnerProperty.getSecond();
 
@@ -46,7 +46,7 @@ public class BurnerStomachHandler {
 
         if (stomach.getFluid().getAmount() < mbConsuming) {
             stomach.getFluid().setAmount(0);
-            return;
+            return false;
         }
 
         if (fluidSuperHeats)
@@ -57,12 +57,12 @@ public class BurnerStomachHandler {
         int newBurnTime = burnerAccessor.createliquidfuel$getRemainingBurnTime() + burnerProperty.getFirst();
 
         if (newBurnTime > BlazeBurnerBlockEntity.MAX_HEAT_CAPACITY)
-            return;
+            return false;
 
         burnerAccessor.createliquidfuel$setRemainingBurnTime(newBurnTime);
 
         stomach.getFluid().shrink(mbConsuming);
-
+        return true;
     }
 
     public static void tryUpdateFuel(@NotNull SmartBlockEntity entity, ItemStack itemStack, boolean forceOverflow, boolean simulate, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
+++ b/src/main/java/com/forsteri/createliquidfuel/core/BurnerStomachHandler.java
@@ -85,15 +85,15 @@ public class BurnerStomachHandler {
         if (!BurnerStomachHandler.LIQUID_BURNER_FUEL_MAP.containsKey(fluidStack.getFluid()))
             return;
 
+
         if (stomach.getFluid().getAmount() + fluidStack.getAmount() > stomach.getCapacity()) {
             if (!forceOverflow) return;
         }
 
         if (!simulate) {
-            if (stomach.getFluid().isEmpty())
-                stomach.setFluid(fluidStack.copy());
-            else
-                stomach.getFluid().grow(fluidStack.getAmount());
+            int amount = fluidStack.getAmount();
+            FluidStack drained = handler.drain(amount, IFluidHandler.FluidAction.EXECUTE);
+            stomach.fill(drained, IFluidHandler.FluidAction.EXECUTE);
         }
 
         cir.setReturnValue(true);

--- a/src/main/java/com/forsteri/createliquidfuel/mixin/MixinBlazeBurnerBlock.java
+++ b/src/main/java/com/forsteri/createliquidfuel/mixin/MixinBlazeBurnerBlock.java
@@ -1,0 +1,24 @@
+package com.forsteri.createliquidfuel.mixin;
+
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(BlazeBurnerBlock.class)
+public class MixinBlazeBurnerBlock {
+    @Redirect(method = "tryInsert", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;shrink(I)V"))
+    private static void tryInsert(ItemStack instance, int p_41775_) {
+        var handler = instance.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM);
+        if (!handler.isPresent()) {
+            instance.shrink(p_41775_);
+        }
+        else if (ForgeHooks.getBurnTime(instance, null) != 0) {
+            instance.shrink(p_41775_);
+        }
+    }
+}

--- a/src/main/java/com/forsteri/createliquidfuel/mixin/MixinBlazeBurnerTileEntity.java
+++ b/src/main/java/com/forsteri/createliquidfuel/mixin/MixinBlazeBurnerTileEntity.java
@@ -52,9 +52,9 @@ public abstract class MixinBlazeBurnerTileEntity extends SmartBlockEntity {
         };
     }
 
-    @Inject(method = "tick", at = @At("TAIL"))
+    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/processing/burner/BlazeBurnerBlockEntity;updateBlockState()V", ordinal = 1), cancellable = true)
     public void tick(CallbackInfo info) {
-        BurnerStomachHandler.tick(this);
+        if (BurnerStomachHandler.tick(this)) info.cancel();
     }
 
     @Inject(method = "read", at = @At("TAIL"))

--- a/src/main/resources/createliquidfuel.mixins.json
+++ b/src/main/resources/createliquidfuel.mixins.json
@@ -6,6 +6,7 @@
   "refmap": "CreateLiquidFuel.refmap.json",
   "mixins": [
     "BlazeBurnerAccessor",
+    "MixinBlazeBurnerBlock",
     "MixinBlazeBurnerTileEntity"
   ],
   "client": [


### PR DESCRIPTION
1.烈焰人燃烧室的`tryInsert`方法只要在`tryUpdateFuel`返回true后一定会调用，所以就一定吞掉物品，这里给他redirect了，让它不再吞物品。
2.在`BlazeBurnerBlockEntity`的`remainingBurnTime`为0时必然会执行`updateBlockState`。此时会有很小的一段时间内烈焰人的`HeatLevel`为`SMOULDERING`（即使游戏内察觉不到），这个变化会被柴油动力的大型发酵罐注意到从而终止配方进行。这里给它取消掉可能不是什么好的解决方案，但是在游戏内的表现几乎看不出区别，但又能修复此bug